### PR TITLE
Create documents directory when needed for tessdata

### DIFF
--- a/Classes/Tesseract.mm
+++ b/Classes/Tesseract.mm
@@ -66,6 +66,7 @@ namespace tesseract {
         NSString *bundlePath = [[NSBundle bundleForClass:[self class]] bundlePath];
         NSString *tessdataPath = [bundlePath stringByAppendingPathComponent:_dataPath];
         if (tessdataPath) {
+            [fileManager createDirectoryAtPath:documentPath withIntermediateDirectories:YES attributes:nil error:NULL];
             [fileManager copyItemAtPath:tessdataPath toPath:dataPath error:nil];
         }
     }


### PR DESCRIPTION
On a different computer, when running unit tests involving tesseract-ios, I found the documents directory did not exist, causing tesseract to fail. This commit creates the documents directory, which solves this problem and fails silently when not required.
