### PR TITLE
Adding clear method to prevent memory leaks

### DIFF
--- a/Classes/Tesseract.h
+++ b/Classes/Tesseract.h
@@ -23,5 +23,6 @@
 - (BOOL)setLanguage:(NSString *)language;
 - (BOOL)recognize;
 - (NSString *)recognizedText;
+- (void)clear;
 
 @end

--- a/Classes/Tesseract.mm
+++ b/Classes/Tesseract.mm
@@ -116,6 +116,12 @@ namespace tesseract {
     return [NSString stringWithUTF8String:utf8Text];
 }
 
+- (void)clear
+{
+    _tesseract->Clear();
+    _tesseract->End();
+}
+
 - (void)setImage:(UIImage *)image
 {
     free(_pixels);

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Here is the default workflow to extract text from an image:
  - Set the image to analyze
  - Start recognition
  - Get recognized text
+ - Clear
  
  
 Code Sample
@@ -48,6 +49,7 @@ Code Sample
     [tesseract recognize];
     
     NSLog(@"%@", [tesseract recognizedText]);
+    [tesseract clear];
  
  
 Method reference
@@ -97,3 +99,8 @@ Start text recognition. You might want to launch this process in background with
 
 Get the text extracted from the image.
 
+### -clear ###
+
+`- (void) clear`
+
+Clears Tesseract object after text has been recognized from image. Preventing memory leaks.


### PR DESCRIPTION
I've added a new method in Tesseract class in order to prevent memory leaks. 
When an image was read the memory allocated in operation was not freed properly. Calling `clear` method fixes this and allow multiple usages through app lifecycle.
