### PR TITLE
Added free(_pixels) in clear method to release memory used by the image

### DIFF
--- a/Classes/Tesseract.mm
+++ b/Classes/Tesseract.mm
@@ -118,6 +118,7 @@ namespace tesseract {
 
 - (void)clear
 {
+    free(_pixels);
     _tesseract->Clear();
     _tesseract->End();
 }


### PR DESCRIPTION
In my tests I was having the following memory plot:
http://i.imgur.com/Tc0yDUZ.png
The app would go from 13MB to 100MB while processing, and would retain 50MB in memory, if another tesseract recognition were made, more 50MB allocated.
Using instruments I figured out that 99% of my memory would be in

```
_pixels = (uint32_t *) malloc(width * height * sizeof(uint32_t));
```

then I freed _pixels in clear method and the resulting plot is:

http://i.imgur.com/PXJL5qR.png

After the recognition is done, the memory goes by 30MB, but even if there is another recognition, it won't increase memory again.
