### PR TITLE
fix NULL recognized string bug

### DIFF
--- a/Classes/Tesseract.mm
+++ b/Classes/Tesseract.mm
@@ -195,7 +195,7 @@ namespace tesseract {
 
 - (NSString *)recognizedText {
     char* utf8Text = _tesseract->GetUTF8Text();
-    NSString *text = [NSString stringWithUTF8String:utf8Text];
+    NSString *text = utf8Text ? [NSString stringWithUTF8String: utf8Text] : @"";
     delete[] utf8Text;
     return text;
 }


### PR DESCRIPTION
Calling the recognizedString method, it will crash if the utf8Text is NULL.
This pull request fixes it.
@ldiqual 
